### PR TITLE
add, rts instructions

### DIFF
--- a/llvm/lib/Target/ICMC/CMakeLists.txt
+++ b/llvm/lib/Target/ICMC/CMakeLists.txt
@@ -3,6 +3,7 @@ add_llvm_component_group(ICMC)
 set(LLVM_TARGET_DEFINITIONS ICMC.td)
 
 tablegen(LLVM ICMCGenRegisterInfo.inc -gen-register-info)
+tablegen(LLVM ICMCGenInstrInfo.inc -gen-instr-info)
 
 add_public_tablegen_target(ICMCCommonTableGen)
 

--- a/llvm/lib/Target/ICMC/ICMC.td
+++ b/llvm/lib/Target/ICMC/ICMC.td
@@ -2,7 +2,6 @@ include "llvm/Target/Target.td"
 
 include "ICMCRegisterInfo.td"
 include "ICMCInstrInfo.td"
-include "ICMCInstrFormats.td"
 include "ICMCCallingConv.td"
 
 

--- a/llvm/lib/Target/ICMC/ICMCInstrFormats.td
+++ b/llvm/lib/Target/ICMC/ICMCInstrFormats.td
@@ -1,0 +1,59 @@
+// define scheduler resources associated with def operands.
+// 32 or 64-bit integer ALU operations
+def WriteIALU       : SchedWrite;    
+def ReadIALU        : SchedRead;
+
+
+// format specifies the encoding used by the instruction
+class InstFormat<bits<5> val> {
+    bits<5> Value = val;
+}
+def InstFormatPseudo : InstFormat<0>;
+def InstFormatR      : InstFormat<1>;
+
+
+// base opcode map
+class RISCWOpcode<bits<7> val> {
+    bits<7> Value = val;
+}
+def OPC_OP : RISCWOpcode<0b0110011>;
+
+
+class RWInst<dag outs, dag ins, string opcodestr, string argstr,
+  list<dag> pattern, InstFormat format> : Instruction {
+    field bits<32> Inst;
+    field bits<32> SoftFail = 0;
+    let Size = 4;
+
+    bits<7> Opcode = 0;
+
+    let Inst{6-0} = Opcode;
+
+    let Namespace = "RISCW";
+
+    dag OutOperandList = outs;
+    dag InOperandList = ins;
+    let AsmString = opcodestr # "\t" # argstr;
+    let Pattern = pattern;
+
+    let TSFlags{4-0} = format.Value;
+}
+
+// Instruction formats 
+class RWInstR<bits<7> funct7, bits<3> funct3, RISCWOpcode opcode, dag outs,
+  dag ins, string opcodestr, string argstr> : RWInst<outs, ins, opcodestr, argstr, [], InstFormatR> {
+    bits<5> rs2;
+    bits<5> rs1;
+    bits<5> rd;
+
+    let Inst{31-25} = funct7;
+    let Inst{24-20} = rs2;
+    let Inst{19-15} = rs1;
+    let Inst{14-12} = funct3;
+    let Inst{11-7} = rd;
+    let Opcode = opcode.Value;
+}
+
+
+
+

--- a/llvm/lib/Target/ICMC/ICMCInstrFormats.td
+++ b/llvm/lib/Target/ICMC/ICMCInstrFormats.td
@@ -13,23 +13,24 @@ def InstFormatR      : InstFormat<1>;
 
 
 // base opcode map
-class RISCWOpcode<bits<7> val> {
-    bits<7> Value = val;
+class ICMCOpcode<bits<6> val> {
+    bits<6> Value = val;
 }
-def OPC_OP : RISCWOpcode<0b0110011>;
+def OPC_ADD : ICMCOpcode<0b100000>;
+def OPC_RTS : ICMCOpcode<0b000100>;
 
 
-class RWInst<dag outs, dag ins, string opcodestr, string argstr,
+class ICMCInst<dag outs, dag ins, string opcodestr, string argstr,
   list<dag> pattern, InstFormat format> : Instruction {
-    field bits<32> Inst;
-    field bits<32> SoftFail = 0;
+    field bits<16> Inst;
+    field bits<16> SoftFail = 0;
     let Size = 4;
 
-    bits<7> Opcode = 0;
+    bits<6> Opcode = 0;
 
-    let Inst{6-0} = Opcode;
+    let Inst{5-0} = Opcode;
 
-    let Namespace = "RISCW";
+    let Namespace = "ICMC";
 
     dag OutOperandList = outs;
     dag InOperandList = ins;
@@ -40,20 +41,24 @@ class RWInst<dag outs, dag ins, string opcodestr, string argstr,
 }
 
 // Instruction formats 
-class RWInstR<bits<7> funct7, bits<3> funct3, RISCWOpcode opcode, dag outs,
-  dag ins, string opcodestr, string argstr> : RWInst<outs, ins, opcodestr, argstr, [], InstFormatR> {
-    bits<5> rs2;
-    bits<5> rs1;
-    bits<5> rd;
+class ICMCInstR<bits<1> c, ICMCOpcode opcode, dag outs,
+  dag ins, string opcodestr, string argstr> : ICMCInst<outs, ins, opcodestr, argstr, [], InstFormatR> {
+    bits<3> rs2;
+    bits<3> rs1;
+    bits<3> rd;
 
-    let Inst{31-25} = funct7;
-    let Inst{24-20} = rs2;
-    let Inst{19-15} = rs1;
-    let Inst{14-12} = funct3;
-    let Inst{11-7} = rd;
+    let Inst{15} = c;
+    let Inst{14-12} = rs2;
+    let Inst{11-9} = rs1;
+    let Inst{8-6} = rd;
     let Opcode = opcode.Value;
 }
 
+class ICMCInstRet<ICMCOpcode opcode, dag outs,
+  dag ins, string opcodestr, string argstr> : ICMCInst<outs, ins, opcodestr, argstr, [], InstFormatR> {
+
+    let Opcode = opcode.Value;
+}
 
 
 

--- a/llvm/lib/Target/ICMC/ICMCInstrInfo.td
+++ b/llvm/lib/Target/ICMC/ICMCInstrInfo.td
@@ -1,0 +1,14 @@
+include "ICMCInstrFormats.td"
+
+// procedure return
+def ret : SDNode<"RISCWISD::Ret", SDTNone,
+        [SDNPHasChain, SDNPOptInGlue, SDNPVariadic]>;
+
+// add instruction
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class ALU <bits<7> funct7, bits<3> funct3, string opcodestr>
+    : RWInstR<funct7, funct3, OPC_OP, (outs SP:$rd), (ins SP:$rs1, SP:$rs2),
+        opcodestr, "$rd, $rs1, $rs2">;
+
+def ADD  : ALU<0b0000000, 0b000, "add">, Sched<[WriteIALU, ReadIALU, ReadIALU]>;
+

--- a/llvm/lib/Target/ICMC/ICMCInstrInfo.td
+++ b/llvm/lib/Target/ICMC/ICMCInstrInfo.td
@@ -1,14 +1,32 @@
 include "ICMCInstrFormats.td"
 
-// procedure return
-def ret : SDNode<"RISCWISD::Ret", SDTNone,
+def ret : SDNode<"ICMC::RTS", SDTNone,
         [SDNPHasChain, SDNPOptInGlue, SDNPVariadic]>;
 
 // add instruction
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class ALU <bits<7> funct7, bits<3> funct3, string opcodestr>
-    : RWInstR<funct7, funct3, OPC_OP, (outs SP:$rd), (ins SP:$rs1, SP:$rs2),
+class ALU <bits<1> c, string opcodestr>
+    : ICMCInstR<c, OPC_ADD, (outs Generic:$rd), (ins Generic:$rs1, Generic:$rs2),
         opcodestr, "$rd, $rs1, $rs2">;
 
-def ADD  : ALU<0b0000000, 0b000, "add">, Sched<[WriteIALU, ReadIALU, ReadIALU]>;
+def ADD  : ALU<0b0, "add">, Sched<[WriteIALU, ReadIALU, ReadIALU]>;
 
+// rts instruction
+let isBarrier = 1, isReturn = 1, isTerminator = 1 in
+class RET <string opcodestr>
+    : ICMCInstRet<OPC_RTS, (outs), (ins),
+        opcodestr, "">;
+
+def RTS  : RET<"rts">, Sched<[]>;
+
+
+// generic pattern classes
+class PatSPSP<SDPatternOperator OpNode, ICMCInst Inst>
+    : Pat<(OpNode Generic:$rs1, Generic:$rs2), (Inst Generic:$rs1, Generic:$rs2)>;
+
+class PatSP<SDPatternOperator OpNode, ICMCInst Inst>
+    : Pat<(OpNode), (Inst)>;
+
+// simple operations
+def : PatSPSP<add, ADD>; 
+def : PatSP<ret, RTS>;

--- a/llvm/lib/Target/ICMC/MCTargetDesc/ICMCMCTargetDesc.cpp
+++ b/llvm/lib/Target/ICMC/MCTargetDesc/ICMCMCTargetDesc.cpp
@@ -1,3 +1,5 @@
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 
@@ -7,6 +9,10 @@
 #define GET_REGINFO_ENUM
 #define GET_REGINFO_MC_DESC
 #include "ICMCGenRegisterInfo.inc"
+
+#define GET_INSTRINFO_MC_DESC
+#define ENABLE_INSTR_PREDICATE_VERIFIER
+#include "ICMCGenInstrInfo.inc"
 
 
 using namespace llvm;
@@ -24,13 +30,19 @@ ICMCMCAsmInfo::ICMCMCAsmInfo(const Triple &TT, const MCTargetOptions &Options){
 static MCRegisterInfo *createICMCMCRegisterInfo(const Triple &TT) {
     MCRegisterInfo *X = new MCRegisterInfo();
     InitICMCMCRegisterInfo(X, ICMC::SP, 0, 0, ICMC::PC);
-    printf("%p\n", (void*) X);
+    return X;
+}
+
+static MCInstrInfo *createICMCMCInstrInfo(void) {
+    MCInstrInfo *X = new MCInstrInfo();
+    InitICMCMCInstrInfo(X);
     return X;
 }
 
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeICMCTargetMC() {
     Target T = getTheICMCTarget();
     RegisterMCAsmInfo<ICMCMCAsmInfo> X(T);
+    TargetRegistry::RegisterMCInstrInfo(T, createICMCMCInstrInfo);
     TargetRegistry::RegisterMCRegInfo(T, createICMCMCRegisterInfo);
 }
 


### PR DESCRIPTION
The files ICMCInstrFormats.td and ICMCInstrInfo.td were created to implement the ADD and RTS instructions used for testing. The implementation of the instructions was based on the RISCW architecture.