### PR TITLE
ICMC linker

### DIFF
--- a/lld/ELF/Arch/ICMC.cpp
+++ b/lld/ELF/Arch/ICMC.cpp
@@ -1,0 +1,40 @@
+#include "Relocations.h"
+#include "Target.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/Support/Endian.h"
+
+using namespace llvm;
+using namespace llvm::object;
+using namespace llvm::ELF;
+using namespace llvm::support::endian;
+using namespace lld;
+using namespace lld::elf;
+
+
+namespace {
+class ICMC final : public TargetInfo {
+public:
+  RelExpr getRelExpr(RelType type, const Symbol &s,
+                     const uint8_t *loc) const override;
+  void relocate(uint8_t *loc, const Relocation &rel,
+                uint64_t val) const override;
+};
+} // namespace
+
+RelExpr
+ICMC::getRelExpr(RelType type, const Symbol &s, const uint8_t *loc) const {
+  return R_ABS;
+}
+
+void ICMC::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
+  switch(rel.type){
+  case R_ICMC_16:
+    write16be(loc, (val-0x110b4)>>1);
+    break;
+  }
+}
+
+TargetInfo *elf::getICMCTargetInfo() {
+  static ICMC target;
+  return &target;
+}

--- a/lld/ELF/CMakeLists.txt
+++ b/lld/ELF/CMakeLists.txt
@@ -22,6 +22,7 @@ add_lld_library(lldELF
   Arch/SPARCV9.cpp
   Arch/X86.cpp
   Arch/X86_64.cpp
+  Arch/ICMC.cpp
   ARMErrataFix.cpp
   CallGraphSort.cpp
   DWARF.cpp

--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -87,6 +87,8 @@ TargetInfo *elf::getTarget() {
     return getSPARCV9TargetInfo();
   case EM_X86_64:
     return getX86_64TargetInfo();
+  case EM_ICMC:
+    return getICMCTargetInfo();
   }
   llvm_unreachable("unknown target machine");
 }

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -187,6 +187,7 @@ TargetInfo *getRISCVTargetInfo();
 TargetInfo *getSPARCV9TargetInfo();
 TargetInfo *getX86TargetInfo();
 TargetInfo *getX86_64TargetInfo();
+TargetInfo *getICMCTargetInfo();
 template <class ELFT> TargetInfo *getMipsTargetInfo();
 
 struct ErrorPlace {

--- a/llvm/lib/Target/ICMC/AsmParser/ICMCAsmParser.cpp
+++ b/llvm/lib/Target/ICMC/AsmParser/ICMCAsmParser.cpp
@@ -359,7 +359,7 @@ bool ICMCAsmParser::tryParseRegisterOperand(OperandVector &Operands) {
 }
 
 bool ICMCAsmParser::ParseDirective(AsmToken DirectiveID) {
-  llvm_unreachable("ParseDirective not implemented");
+  return true;
 }
 
 bool ICMCAsmParser::MatchAndEmitInstruction(


### PR DESCRIPTION
The ICMC Linker is used as normally: many objects can be added as arguments and an output ELF will be generated. It is important to note that a bootstrapper (in the likes of crt*.o for X86) is necessary, as execution always initiates at the start of .text in the ICMC Architecture.
